### PR TITLE
Added no_run for example api where a get() is involved

### DIFF
--- a/src/data_structures/artist.rs
+++ b/src/data_structures/artist.rs
@@ -146,7 +146,7 @@ impl ArtistQueryBuilder {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```rust,no_run
     /// use discogs::Discogs;
     ///
     /// let releases = Discogs::new("USER_AGENT")
@@ -177,12 +177,11 @@ impl ArtistQueryBuilder {
         self.per_page = per_page;
         self
     }
-    /// Returns an instance of the `ArtistReleasesQueryBuilder` structure for the specified id
-    /// This allows you to pass parameters to build a request.
+    /// Perform request for Artist Releases
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```rust,no_run
     /// use discogs::Discogs;
     ///
     /// let releases = Discogs::new("USER_AGENT")

--- a/src/data_structures/label.rs
+++ b/src/data_structures/label.rs
@@ -120,7 +120,7 @@ impl LabelQueryBuilder {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```rust,no_run
     /// use discogs::Discogs;
     ///
     /// let label = Discogs::new("USER_AGENT")

--- a/src/data_structures/master.rs
+++ b/src/data_structures/master.rs
@@ -138,7 +138,7 @@ impl MasterQueryBuilder {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```rust,no_run
     /// use discogs::data_structures::MasterQueryBuilder;
     ///
     /// let master = MasterQueryBuilder::new(7896,

--- a/src/data_structures/release.rs
+++ b/src/data_structures/release.rs
@@ -189,7 +189,7 @@ impl ReleaseQueryBuilder {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```rust,no_run
     /// use discogs::data_structures::ReleaseQueryBuilder;
     ///
     /// let rqb = ReleaseQueryBuilder::new(128,

--- a/src/data_structures/search.rs
+++ b/src/data_structures/search.rs
@@ -454,7 +454,7 @@ impl SearchQueryBuilder {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```rust,no_run
     /// use discogs::data_structures::SearchQueryBuilder;
     ///
     /// let sqb = SearchQueryBuilder::new(discogs::API_URL.to_string(),


### PR DESCRIPTION
Added no_run on *::get()  examples